### PR TITLE
Add pubspec.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
+pubspec.lock


### PR DESCRIPTION
## Description

Add `pubspec.lock` to `.gitignore` to exclude from version control.