### PR TITLE
same borderRadius for  Background and Content

### DIFF
--- a/example/lib/examples/inspiration_example.dart
+++ b/example/lib/examples/inspiration_example.dart
@@ -68,6 +68,10 @@ class InspirationExample extends StatelessWidget {
           ///Size perameter
           size: horizontalView ? widthSize : heightSize,
 
+          ///Background and Content Border Radius parameter
+          backgroundBorderRadius:
+              BorderRadius.horizontal(right: Radius.circular(10)),
+
           ///Cover parameter
           cover: ClipRRect(
             borderRadius: BorderRadius.horizontal(right: Radius.circular(10)),

--- a/lib/src/widgets/animated_book_widget.dart
+++ b/lib/src/widgets/animated_book_widget.dart
@@ -269,6 +269,7 @@ class _AnimatedBookWidgetState extends State<AnimatedBookWidget>
               AnimatedContentWidget(
                 bookAnimation: animation,
                 delegate: contentDelegate,
+                borderRadius: backgroundBorderRadius,
               ),
               AnimatedCoverWidget(
                 listenable: animation,

--- a/lib/src/widgets/animated_content_widget.dart
+++ b/lib/src/widgets/animated_content_widget.dart
@@ -12,9 +12,12 @@ class AnimatedContentWidget extends StatelessWidget {
   /// The [delegate] is the delegate responsible for building
   /// the animated content.
   ///
+  /// The [borderRadius] is the border radius of the book.
+  ///
   const AnimatedContentWidget({
     required this.bookAnimation,
     required this.delegate,
+    required this.borderRadius,
     super.key,
   });
 
@@ -24,16 +27,22 @@ class AnimatedContentWidget extends StatelessWidget {
   /// The delegate responsible for building the animated content.
   final AnimatedContentDelegate delegate;
 
+  /// The border radius of the book.
+  final BorderRadius borderRadius;
+
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: bookAnimation,
-      builder: (context, child) => delegate.build(
-        context,
-        bookAnimation,
-        child,
+    return ClipRRect(
+      borderRadius: borderRadius,
+      child: AnimatedBuilder(
+        animation: bookAnimation,
+        builder: (context, child) => delegate.build(
+          context,
+          bookAnimation,
+          child,
+        ),
+        child: delegate.contentChild,
       ),
-      child: delegate.contentChild,
     );
   }
 }

--- a/lib/src/widgets/animated_content_widget.dart
+++ b/lib/src/widgets/animated_content_widget.dart
@@ -17,7 +17,7 @@ class AnimatedContentWidget extends StatelessWidget {
   const AnimatedContentWidget({
     required this.bookAnimation,
     required this.delegate,
-    required this.borderRadius,
+    this.borderRadius = BorderRadius.zero,
     super.key,
   });
 


### PR DESCRIPTION
## Description

When the cover has rounded corners, as in the case of the inspiration examples, adding a similar backgroundBorderRadius improves the visual aspect. However, this did not have an effect on the container. The changes are so that the backgroundBorderRadius has an effect on both the background and the content.

## Checklist

- [x] Tested on iOS
- [x] Tested on Android
- [x] Tested on small screens
- [ ] Unit tests

## Images/Videos
before:
![image](https://github.com/the-d-velopers/animated_book_widget/assets/4116353/d1381bfb-066e-454f-82ab-5618954be225)
now:
![image](https://github.com/the-d-velopers/animated_book_widget/assets/4116353/732954ad-f8cd-4785-8aa2-3a49c6d7f326)
